### PR TITLE
修复 GitHub 自动标签工作流

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
 # v5 格式文档: https://github.com/actions/labeler
 
 # 文档相关
-docs:
+"docs / 文档":
   - changed-files:
       - any-glob-to-any-file:
           - docs/**/*
@@ -15,49 +15,49 @@ docs:
           - GEMINI.md
 
 # 核心转换引擎
-core:
+"core / 核心":
   - changed-files:
       - any-glob-to-any-file:
           - src/core/**/*
 
 # 数据模型
-models:
+"models / 数据模型":
   - changed-files:
       - any-glob-to-any-file:
           - src/models/**/*
 
 # 服务层
-services:
+"services / 服务":
   - changed-files:
       - any-glob-to-any-file:
           - src/services/**/*
 
 # UI 层
-ui:
+"ui / 界面":
   - changed-files:
       - any-glob-to-any-file:
           - src/ui/**/*
 
 # 工作线程
-workers:
+"workers / 工作线程":
   - changed-files:
       - any-glob-to-any-file:
           - src/workers/**/*
 
 # 工具类
-utils:
+"utils / 工具":
   - changed-files:
       - any-glob-to-any-file:
           - src/utils/**/*
 
 # 测试
-tests:
+"test / 测试":
   - changed-files:
       - any-glob-to-any-file:
           - tests/**/*
 
 # CI/CD
-ci:
+"ci / 持续集成":
   - changed-files:
       - any-glob-to-any-file:
           - .github/**/*
@@ -65,7 +65,30 @@ ci:
           - .gitignore
 
 # 资源文件
-resources:
+"resources / 资源":
   - changed-files:
       - any-glob-to-any-file:
           - resources/**/*
+
+# 格式与数据源模块
+"easyeda / 嘉立创":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/core/easyeda/**/*
+          - tools/python/**/*
+
+"kicad / KiCad":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/core/kicad/**/*
+
+"network / 网络":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/core/network/**/*
+
+"cli / 命令行":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/cli/**/*
+          - tools/**/*

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -89,6 +89,10 @@
   color: "fe81f4"
   description: "Icons, images, QML / 图标、图片、QML"
 
+- name: "utils / 工具"
+  color: "6f42c1"
+  description: "Shared utility code / 共享工具代码"
+
 # ============================================
 # 状态标签 (Status Labels)
 # ============================================

--- a/.github/sync-labels.sh
+++ b/.github/sync-labels.sh
@@ -44,6 +44,7 @@ gh label create "workers / 工作线程" --color "b5a4fa" --description "Backgro
 gh label create "cli / 命令行" --color "ededed" --description "Command line interface / 命令行工具" --repo "$REPO" --force
 gh label create "models / 数据模型" --color "0e28c6" --description "Data models / 数据模型" --repo "$REPO" --force
 gh label create "resources / 资源" --color "fe81f4" --description "Icons, images, QML / 图标、图片、QML" --repo "$REPO" --force
+gh label create "utils / 工具" --color "6f42c1" --description "Shared utility code / 共享工具代码" --repo "$REPO" --force
 
 # 状态标签
 gh label create "good first issue / 新手友好" --color "7057ff" --description "Good for newcomers / 适合新手参与" --repo "$REPO" --force


### PR DESCRIPTION
## 变更说明

- 统一 `.github/labeler.yml` 与仓库现有双语标签名称。
- 将测试路径映射到 `test / 测试`，避免继续生成旧的 `tests` 标签。
- 补齐 EasyEDA、KiCad、网络、CLI 模块的路径标签规则。
- 增加 `utils / 工具` 标签定义及同步脚本创建逻辑。

## 验证

- 使用 Ruby YAML 解析验证 `.github/labeler.yml` 和 `.github/labels.yml`。
- `git diff --check` 通过。