### PR TITLE
fix(ci): 修复文档工作流 Code Scanning 权限告警

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -7,6 +7,9 @@ on:
       - 'mkdocs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 描述
修复 GitHub Code Scanning 报告的 `actions/missing-workflow-permissions` 告警。

在 `.github/workflows/docs-check.yml` 添加显式权限配置，仅授予工作流读取仓库内容所需的 `contents: read` 权限。

感谢 @Harry1999-sky 的协作。

## 相关 Issue
无

## 更改类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他

## 测试
- [x] YAML 变更执行 `git diff --check`
- [ ] 单元测试通过
- [ ] 手动测试
- [ ] 添加了新的测试用例

## 检查清单
- [x] 代码遵循项目的编码规范
- [x] 添加了必要的配置
- [ ] 所有测试通过
- [x] 提交信息符合规范

## 附加信息
目标分支为 `v3.1.12`。不执行自动合并。
