### PR TITLE
ci(windows): add ARM64 build and release packages

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'CMake version to install'
     required: false
     default: '3.22'
+  setup-cmake:
+    description: 'Whether to install the pinned CMake version'
+    required: false
+    default: 'true'
   qt-version:
     description: 'Qt version to install'
     required: false
@@ -74,6 +78,7 @@ runs:
           libglib2.0-0
 
     - name: 'Setup CMake'
+      if: inputs.setup-cmake == 'true'
       uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
       with:
         cmake-version: ${{ inputs.cmake-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,6 +281,7 @@ jobs:
 
       - name: 'CCache Stats'
         if: matrix.enable_ccache
+        shell: pwsh
         run: |
           ccache -sv
           echo "## CCache Statistics" >> $GITHUB_STEP_SUMMARY
@@ -316,6 +317,7 @@ jobs:
           "| Free disk | ${freeDisk} GB |" >> $env:GITHUB_STEP_SUMMARY
 
       - name: 'Run Tests'
+        shell: pwsh
         run: |
           $env:QT_QPA_PLATFORM = "offscreen"
           ctest --test-dir build -C ${{ env.BUILD_TYPE }} --output-on-failure --no-tests=error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,6 +253,7 @@ jobs:
             win-ccache-${{ matrix.platform }}-
 
       - name: 'Configure CMake (Ninja + ccache) with vcpkg'
+        shell: pwsh
         run: |
           $cmakeArgs = @(
             '-B', 'build',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,19 +158,34 @@ jobs:
 
 
   windows-build:
-    name: 'Build Windows'
-    runs-on: windows-2022
+    name: 'Build Windows (${{ matrix.name }})'
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     env:
-      WindowsSDKVersion: '10.0.22621.0'
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: 'Windows MSVC'
-            platform: 'msvc2019_64'
+            runner: 'windows-2022'
+            platform: 'msvc2022_64'
             generator: 'Ninja'
             arch: 'x64'
+            qt_host: 'windows'
+            qt_arch: 'win64_msvc2022_64'
+            vcpkg_triplet: 'x64-windows'
+            enable_ccache: true
+          - name: 'Windows ARM64'
+            runner: 'windows-11-arm'
+            platform: 'msvc2022_arm64'
+            generator: 'Ninja'
+            arch: 'arm64'
+            qt_host: 'windows_arm64'
+            qt_arch: 'win64_msvc2022_arm64'
+            vcpkg_triplet: 'arm64-windows'
+            enable_ccache: false
     steps:
       - name: 'Checkout Source code'
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -185,7 +200,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: ${{ matrix.arch }}
-          vsversion: '2022'
 
       - name: 'Setup vcpkg'
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
@@ -198,9 +212,9 @@ jobs:
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
           qt-version: ${{ env.QT_VERSION }}
-          qt-host: 'windows'
+          qt-host: ${{ matrix.qt_host }}
           qt-target: 'desktop'
-          qt-arch: 'win64_msvc2022_64'
+          qt-arch: ${{ matrix.qt_arch }}
           enable-ccache: 'false'
           enable-sccache: 'false'
 
@@ -216,6 +230,7 @@ jobs:
           }
 
       - name: 'Install ccache'
+        if: matrix.enable_ccache
         shell: pwsh
         run: |
           choco install ccache --version=4.11.1 -y --no-progress
@@ -226,6 +241,7 @@ jobs:
           echo "CCACHE_COMPILERCHECK=content" >> $env:GITHUB_ENV
 
       - name: 'Restore CCache'
+        if: matrix.enable_ccache
         id: cache-ccache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -238,25 +254,32 @@ jobs:
 
       - name: 'Configure CMake (Ninja + ccache) with vcpkg'
         run: |
-          cmake -B build -G "Ninja" `
-            -DCMAKE_PREFIX_PATH="$env:Qt6_DIR" `
-            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} `
-            -DCMAKE_C_FLAGS_RELWITHDEBINFO="/MD /O2 /Ob1 /DNDEBUG /Z7" `
-            -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="/MD /O2 /Ob1 /DNDEBUG /Z7" `
-            -DCMAKE_C_COMPILER=cl `
-            -DCMAKE_CXX_COMPILER=cl `
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache `
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
-            -DENABLE_SYMBOL_FOOTPRINT_DEBUG_EXPORT=OFF `
-            -DEASYKICONVERTER_BUILD_TESTS=ON `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DCI=ON
+          $cmakeArgs = @(
+            '-B', 'build',
+            '-G', 'Ninja',
+            "-DCMAKE_PREFIX_PATH=$env:Qt6_DIR",
+            "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}",
+            '-DCMAKE_C_FLAGS_RELWITHDEBINFO=/MD /O2 /Ob1 /DNDEBUG /Z7',
+            '-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=/MD /O2 /Ob1 /DNDEBUG /Z7',
+            '-DCMAKE_C_COMPILER=cl',
+            '-DCMAKE_CXX_COMPILER=cl',
+            '-DENABLE_SYMBOL_FOOTPRINT_DEBUG_EXPORT=OFF',
+            '-DEASYKICONVERTER_BUILD_TESTS=ON',
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake",
+            '-DCI=ON'
+          )
+          if ("${{ matrix.enable_ccache }}" -eq "true") {
+            $cmakeArgs += '-DCMAKE_C_COMPILER_LAUNCHER=ccache'
+            $cmakeArgs += '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+          }
+          cmake @cmakeArgs
 
       - name: 'Build'
         run: |
           cmake --build build --config ${{ env.BUILD_TYPE }} --parallel 16
 
       - name: 'CCache Stats'
+        if: matrix.enable_ccache
         run: |
           ccache -sv
           echo "## CCache Statistics" >> $GITHUB_STEP_SUMMARY
@@ -265,7 +288,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: 'Save CCache'
-        if: always() && steps.cache-ccache.outputs.cache-primary-key != ''
+        if: always() && matrix.enable_ccache && steps.cache-ccache.outputs.cache-primary-key != ''
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.temp }}\ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
             qt_host: 'windows'
             qt_arch: 'win64_msvc2022_64'
             vcpkg_triplet: 'x64-windows'
+            setup_cmake: true
             enable_ccache: true
           - name: 'Windows ARM64'
             runner: 'windows-11-arm'
@@ -185,6 +186,7 @@ jobs:
             qt_host: 'windows_arm64'
             qt_arch: 'win64_msvc2022_arm64'
             vcpkg_triplet: 'arm64-windows'
+            setup_cmake: false
             enable_ccache: false
     steps:
       - name: 'Checkout Source code'
@@ -215,6 +217,7 @@ jobs:
           qt-host: ${{ matrix.qt_host }}
           qt-target: 'desktop'
           qt-arch: ${{ matrix.qt_arch }}
+          setup-cmake: ${{ matrix.setup_cmake }}
           enable-ccache: 'false'
           enable-sccache: 'false'
 

--- a/.github/workflows/pack-windows.yml
+++ b/.github/workflows/pack-windows.yml
@@ -49,6 +49,7 @@ jobs:
             vcpkg_triplet: 'x64-windows'
             qt_host: 'windows'
             qt_arch: 'win64_msvc2022_64'
+            setup_cmake: true
             package_arch: 'x64'
             pak_arch: 'win64'
           - runner: 'windows-11-arm'
@@ -58,6 +59,7 @@ jobs:
             vcpkg_triplet: 'arm64-windows'
             qt_host: 'windows_arm64'
             qt_arch: 'win64_msvc2022_arm64'
+            setup_cmake: false
             package_arch: 'arm64'
             pak_arch: 'win64-arm64'
         type: [portable, installer]
@@ -111,6 +113,7 @@ jobs:
           qt-host: ${{ matrix.config.qt_host }}
           qt-target: ${{ matrix.qt_target }}
           qt-arch: ${{ matrix.config.qt_arch }}
+          setup-cmake: ${{ matrix.config.setup_cmake }}
           enable-ccache: 'false'
           enable-sccache: 'false'
 

--- a/.github/workflows/pack-windows.yml
+++ b/.github/workflows/pack-windows.yml
@@ -370,8 +370,15 @@ jobs:
           if (Test-Path $manifestPath) {
             [xml]$xml = Get-Content $manifestPath
             $xml.Package.Identity.Version = $msixVersion
+            $expectedArchitecture = "${{ matrix.config.package_arch }}"
+            if ($expectedArchitecture -notin @('x64', 'arm64')) {
+              Write-Error "Unsupported MSIX architecture: $expectedArchitecture"
+              exit 1
+            }
+            $xml.Package.Identity.ProcessorArchitecture = $expectedArchitecture
             $xml.Save($manifestPath)
             Write-Host "Manifest version updated to: $msixVersion"
+            Write-Host "Manifest architecture updated to: $expectedArchitecture"
           } else {
             Write-Error "AppxManifest.xml not found at $manifestPath"
             exit 1
@@ -413,6 +420,21 @@ jobs:
                 $manifestInStaging = "$stagingDir\AppxManifest.xml"
                 if (-not (Test-Path $manifestInStaging)) {
                   Write-Error "AppxManifest.xml not found in staging directory at $manifestInStaging"
+                  exit 1
+                }
+
+                [xml]$stagingManifest = Get-Content $manifestInStaging
+                $expectedArchitecture = "${{ matrix.config.package_arch }}"
+                $actualArchitecture = $stagingManifest.Package.Identity.ProcessorArchitecture
+                if ($actualArchitecture -ne $expectedArchitecture) {
+                  Write-Error "MSIX architecture mismatch: expected '$expectedArchitecture', got '$actualArchitecture'"
+                  exit 1
+                }
+                Write-Host "MSIX manifest architecture verified: $actualArchitecture"
+
+                $packagedExecutable = Join-Path $stagingDir 'easykiconverter.exe'
+                if (-not (Test-Path $packagedExecutable)) {
+                  Write-Error "MSIX executable not found in staging directory: $packagedExecutable"
                   exit 1
                 }
       

--- a/.github/workflows/pack-windows.yml
+++ b/.github/workflows/pack-windows.yml
@@ -42,28 +42,24 @@ jobs:
       matrix:
         qt_target: [desktop]
         config:
-          - {
-              runner: 'windows-2022',
-              arch: 'x64',
-              generator: 'Ninja',
-              gen_arch: '',
-              vcpkg_triplet: 'x64-windows',
-              qt_host: 'windows',
-              qt_arch: 'win64_msvc2022_64',
-              package_arch: 'x64',
-              pak_arch: 'win64'
-            },
-          - {
-              runner: 'windows-11-arm',
-              arch: 'arm64',
-              generator: 'Ninja',
-              gen_arch: '',
-              vcpkg_triplet: 'arm64-windows',
-              qt_host: 'windows_arm64',
-              qt_arch: 'win64_msvc2022_arm64',
-              package_arch: 'arm64',
-              pak_arch: 'win64-arm64'
-            }
+          - runner: 'windows-2022'
+            arch: 'x64'
+            generator: 'Ninja'
+            gen_arch: ''
+            vcpkg_triplet: 'x64-windows'
+            qt_host: 'windows'
+            qt_arch: 'win64_msvc2022_64'
+            package_arch: 'x64'
+            pak_arch: 'win64'
+          - runner: 'windows-11-arm'
+            arch: 'arm64'
+            generator: 'Ninja'
+            gen_arch: ''
+            vcpkg_triplet: 'arm64-windows'
+            qt_host: 'windows_arm64'
+            qt_arch: 'win64_msvc2022_arm64'
+            package_arch: 'arm64'
+            pak_arch: 'win64-arm64'
         type: [portable, installer]
     steps:
       - name: 'Checkout Source code'

--- a/.github/workflows/pack-windows.yml
+++ b/.github/workflows/pack-windows.yml
@@ -32,21 +32,37 @@ env:
 
 jobs:
   windows-pack:
-    name: 'VS 2022 ${{ matrix.config.arch }}-${{ matrix.type }}'
-    runs-on: windows-2022
+    name: 'Windows ${{ matrix.config.package_arch }}-${{ matrix.type }}'
+    runs-on: ${{ matrix.config.runner }}
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.config.vcpkg_triplet }}
+      VCPKG_TARGET_TRIPLET: ${{ matrix.config.vcpkg_triplet }}
     strategy:
       fail-fast: false
       matrix:
         qt_target: [desktop]
         config:
           - {
+              runner: 'windows-2022',
               arch: 'x64',
               generator: 'Ninja',
               gen_arch: '',
               vcpkg_triplet: 'x64-windows',
+              qt_host: 'windows',
               qt_arch: 'win64_msvc2022_64',
-              qt_arch_install: 'msvc2022_64',
+              package_arch: 'x64',
               pak_arch: 'win64'
+            },
+          - {
+              runner: 'windows-11-arm',
+              arch: 'arm64',
+              generator: 'Ninja',
+              gen_arch: '',
+              vcpkg_triplet: 'arm64-windows',
+              qt_host: 'windows_arm64',
+              qt_arch: 'win64_msvc2022_arm64',
+              package_arch: 'arm64',
+              pak_arch: 'win64-arm64'
             }
         type: [portable, installer]
     steps:
@@ -84,7 +100,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: ${{ matrix.config.arch }}
-          vsversion: '2022'
 
       - name: 'Setup vcpkg'
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
@@ -97,7 +112,7 @@ jobs:
         with:
           cmake-version: ${{ env.CMAKE_VERSION }}
           qt-version: ${{ env.QT_VERSION }}
-          qt-host: 'windows'
+          qt-host: ${{ matrix.config.qt_host }}
           qt-target: ${{ matrix.qt_target }}
           qt-arch: ${{ matrix.config.qt_arch }}
           enable-ccache: 'false'
@@ -310,7 +325,7 @@ jobs:
 
           # Rename output to standard format
           $setupExe = Get-ChildItem -Path $outputDir -Filter "EasyKiConverter_*_Setup.exe" | Select-Object -First 1
-          $newContentName = "${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}-x64-setup.exe"
+          $newContentName = "${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}-${{ matrix.config.package_arch }}-setup.exe"
           Rename-Item -Path $setupExe.FullName -NewName $newContentName
 
           Write-Host "Installer created at: $outputDir\$newContentName"
@@ -330,7 +345,7 @@ jobs:
         if: matrix.type == 'installer'
         shell: pwsh
         run: |
-          $fileName = "${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}-x64-setup.exe"
+          $fileName = "${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}-${{ matrix.config.package_arch }}-setup.exe"
           $filePath = "$env:GITHUB_WORKSPACE\build\Package\installer\$fileName"
           $hash = Get-FileHash -Path $filePath -Algorithm SHA256
           $hashString = $hash.Hash.ToLower() + " *" + $fileName
@@ -391,7 +406,7 @@ jobs:
                 # 注意：AppxManifest.xml 必须在 staging 目录中，文件名必须为 AppxManifest.xml
                 $stagingDir = "$env:GITHUB_WORKSPACE\build\Staging"
                 $outputDir = "$env:GITHUB_WORKSPACE\build\Package\msix"
-                $msixPath = "$outputDir\${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}.msix"
+                $msixPath = "$outputDir\${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}-${{ matrix.config.package_arch }}.msix"
       
                 mkdir -p $outputDir
       
@@ -422,7 +437,7 @@ jobs:
         if: matrix.type == 'installer'
         shell: pwsh
         run: |
-          $fileName = "${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}.msix"
+          $fileName = "${env:PRODUCT}-${env:VERSION}-g${env:GIT_HASH}-${{ matrix.config.package_arch }}.msix"
           $filePath = "$env:GITHUB_WORKSPACE\build\Package\msix\$fileName"
           $hash = Get-FileHash -Path $filePath -Algorithm SHA256
           $hashString = $hash.Hash.ToLower() + " *" + $fileName
@@ -433,7 +448,7 @@ jobs:
         if: matrix.type == 'portable'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: EasyKiConverter-${{ env.VERSION }}-g${{ env.GIT_HASH }}-x64-portable
+          name: EasyKiConverter-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}-portable
           path: |
             ${{ github.workspace }}/build/Package/portable/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.pak_arch }}.zip
             ${{ github.workspace }}/build/Package/portable/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.pak_arch }}.zip.sha256sum
@@ -443,19 +458,19 @@ jobs:
         if: matrix.type == 'installer'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: EasyKiConverter-${{ env.VERSION }}-g${{ env.GIT_HASH }}-x64-setup
+          name: EasyKiConverter-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}-setup
           path: |
-            ${{ github.workspace }}/build/Package/installer/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-x64-setup.exe
-            ${{ github.workspace }}/build/Package/installer/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-x64-setup.exe.sha256sum
+            ${{ github.workspace }}/build/Package/installer/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}-setup.exe
+            ${{ github.workspace }}/build/Package/installer/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}-setup.exe.sha256sum
           overwrite: true
 
       - name: 'Artifact Upload (MSIX)'
         if: matrix.type == 'installer'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: EasyKiConverter-${{ env.VERSION }}-g${{ env.GIT_HASH }}-x64-msix
+          name: EasyKiConverter-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}-msix
           path: |
-            ${{ github.workspace }}/build/Package/msix/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}.msix
-            ${{ github.workspace }}/build/Package/msix/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}.msix.sha256sum
+            ${{ github.workspace }}/build/Package/msix/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}.msix
+            ${{ github.workspace }}/build/Package/msix/${{ env.PRODUCT }}-${{ env.VERSION }}-g${{ env.GIT_HASH }}-${{ matrix.config.package_arch }}.msix.sha256sum
           overwrite: true
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,9 @@ jobs:
           }
 
           require_asset '*-win64.zip'
+          require_asset '*-win64-arm64.zip'
           require_asset '*-x64-setup.exe'
+          require_asset '*-arm64-setup.exe'
           require_asset '*.x86_64.AppImage'
           require_asset '*.aarch64.AppImage'
           require_asset '*_amd64.deb'
@@ -182,7 +184,8 @@ jobs:
           require_asset '*_aarch64.pkg.tar.zst'
           require_asset '*-intel.dmg'
           require_asset '*-arm64.dmg'
-          require_asset '*.msix'
+          require_asset '*-x64.msix'
+          require_asset '*-arm64.msix'
 
           target_short_sha="${TARGET_SHA:0:7}"
           while IFS= read -r asset; do

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ### 安装
 请前往 [Releases](https://github.com/tangsangsimida/EasyKiConverter/releases) 页面下载适用于您平台的版本：
 
-*   **Windows**: 推荐下载 `.exe` 安装程序（包含完整运行时），或下载 `.zip` 便携版。
+*   **Windows**: 提供 x64 和 ARM64 版本；请按设备架构下载对应的 `.exe` 安装程序或 `.zip` 便携版。
 *   **Linux**: 推荐下载 `.AppImage`（无需安装，赋予执行权限即可运行），或 `.tar.gz` 归档。
 *   **macOS**: 下载 `.dmg` 镜像文件。
 *   **Arch Linux**: `yay -S easykiconverter`

--- a/README_en.md
+++ b/README_en.md
@@ -36,7 +36,7 @@
 ### Installation
 Please visit the [Releases](https://github.com/tangsangsimida/EasyKiConverter/releases) page to download the version for your platform:
 
-*   **Windows**: Recommended to download `.exe` installer (includes complete runtime), or download `.zip` portable version.
+*   **Windows**: x64 and ARM64 builds are available; download the matching `.exe` installer or `.zip` portable package for your device.
 *   **Linux**: Recommended to download `.AppImage` (no installation required, just grant execute permission and run), or `.tar.gz` archive.
 *   **macOS**: Download `.dmg` image file.
 *   **Arch Linux**: `yay -S easykiconverter`

--- a/docs/developer/BUILD.md
+++ b/docs/developer/BUILD.md
@@ -109,6 +109,13 @@ qmake -query QT_VERSION       # 必须为 6.10.2
 1. 安装 Visual Studio 2019 或更高版本
 2. 在安装时选择 "使用 C++ 的桌面开发" 工作负载
 
+Windows 发布构建同时支持以下架构：
+
+- x64：Qt `win64_msvc2022_64`，vcpkg triplet `x64-windows`
+- ARM64：Windows 11 on ARM、Qt `win64_msvc2022_arm64`，vcpkg triplet `arm64-windows`
+
+ARM64 发布包由 GitHub Actions 的 `windows-11-arm` runner 构建，生成 ARM64 便携版、安装程序和 MSIX 包。
+
 ### macOS
 
 #### 使用 Homebrew 安装

--- a/docs/developer/BUILD_en.md
+++ b/docs/developer/BUILD_en.md
@@ -105,6 +105,13 @@ qmake -query QT_VERSION       # must be 6.10.2
 2. Extract to a directory (e.g., C:\mingw64)
 3. Add bin directory to system PATH
 
+Windows release builds support both architectures:
+
+- x64: Qt `win64_msvc2022_64`, vcpkg triplet `x64-windows`
+- ARM64: Windows 11 on Arm, Qt `win64_msvc2022_arm64`, vcpkg triplet `arm64-windows`
+
+The ARM64 release packages are built on the GitHub Actions `windows-11-arm` runner and include portable, installer, and MSIX packages.
+
 ### macOS
 
 #### 1. Install Qt

--- a/docs/user/INSTALLATION_CODES.md
+++ b/docs/user/INSTALLATION_CODES.md
@@ -120,14 +120,14 @@ EasyKiConverter 使用 **Inno Setup** 创建的 Windows 安装程序（.exe 格�
 
 - **名称**: EasyKiConverter Setup
 - **版本**: 3.1.4
-- **架构**: x64
+- **架构**: x64 或 ARM64（根据安装包文件名选择）
 - **类型**: Inno Setup (.exe)
 - **大小**: 约 100-150 MB
 - **签名**: 包含数字签名
 
 ## 系统要求
 
-- **操作系统**: Windows 10/11 (64-bit)
+- **操作系统**: Windows 10/11 (64-bit)，ARM64 安装包需要 Windows on Arm
 - **权限**: 需要管理员权限
 - **磁盘空间**: 至少 200MB
 - **网络**: 不需要（除非从网络下载）

--- a/docs/user/INSTALLATION_CODES_en.md
+++ b/docs/user/INSTALLATION_CODES_en.md
@@ -120,14 +120,14 @@ EasyKiConverter uses **Inno Setup** to create Windows installers (.exe format).
 
 - **Name**: EasyKiConverter Setup
 - **Version**: 3.1.4
-- **Architecture**: x64
+- **Architecture**: x64 or ARM64 (select according to the package filename)
 - **Type**: Inno Setup (.exe)
 - **Size**: Approximately 100-150 MB
 - **Signature**: Includes digital signature
 
 ## System Requirements
 
-- **Operating System**: Windows 10/11 (64-bit)
+- **Operating System**: Windows 10/11 (64-bit); ARM64 packages require Windows on Arm
 - **Permissions**: Administrator privileges required
 - **Disk Space**: Minimum 200MB
 - **Network**: Not required (unless downloading from network)


### PR DESCRIPTION
## Summary
- add Windows ARM64 build and packaging matrix
- produce ARM64 portable ZIP, installer, and MSIX artifacts
- require x64 and ARM64 Windows assets in release validation
- document Windows ARM64 support

## Validation
- GitHub Actions build matrix will validate Windows x64 and ARM64 builds/tests
- Packaging workflow is wired for Windows x64 and ARM64 release artifacts
