### PR TITLE
fix(ci): 修复 AppImage 发布流程与资产校验

### DIFF
--- a/.github/workflows/pack-linux.yml
+++ b/.github/workflows/pack-linux.yml
@@ -363,7 +363,13 @@ jobs:
             exit 1
           fi
           mkdir -p "${APPIMAGE_DST_PATH}/usr/lib"
+          rm -f "${APPIMAGE_DST_PATH}/usr/lib/$REQUIRED_QT_LIBRARY"
           cp -L "$QT_CONTROLS_LIBRARY" "${APPIMAGE_DST_PATH}/usr/lib/$REQUIRED_QT_LIBRARY"
+          if [ ! -f "${APPIMAGE_DST_PATH}/usr/lib/$REQUIRED_QT_LIBRARY" ] || \
+             [ -L "${APPIMAGE_DST_PATH}/usr/lib/$REQUIRED_QT_LIBRARY" ]; then
+            echo "ERROR: $REQUIRED_QT_LIBRARY was not copied as a regular file"
+            exit 1
+          fi
           echo "✓ Copied $REQUIRED_QT_LIBRARY as a regular file"
           
           # 严格验证关键 QML 模块

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
             (cd release_assets && sha256sum -c "$(basename "$checksum")")
             asset_name="${checksum%.sha256sum}"
             [[ -f "$asset_name" ]] || { echo "Checksum has no matching asset: $checksum"; exit 1; }
-            referenced_asset="$(awk '{print $2}' "$checksum" | sed 's/^\*//')"
+            referenced_asset="$(awk '{print $2}' "$checksum" | sed 's/^\*//' | tr -d '\r' | xargs -r basename)"
             [[ "$referenced_asset" == "$(basename "$asset_name")" ]] || {
               echo "Checksum file references an unexpected asset: $checksum"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,10 +200,13 @@ jobs:
           target_short_sha="${TARGET_SHA:0:7}"
           while IFS= read -r asset; do
             filename="$(basename "$asset")"
-            [[ "$filename" == EasyKiConverter-${VERSION}-g${target_short_sha}-* ]] || {
-              echo "Asset version or commit mismatch: $filename"
-              exit 1
-            }
+            case "$filename" in
+              EasyKiConverter-${VERSION}-g${target_short_sha}[-_.]*) ;;
+              *)
+                echo "Asset version or commit mismatch: $filename"
+                exit 1
+                ;;
+            esac
           done < <(find release_assets -maxdepth 1 -type f ! -name '*.sha256sum' -print)
 
           while IFS= read -r checksum; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
 
           release_branch_found=false
           while read -r branch; do
-            if [[ "$branch" =~ origin/(master|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            # 允许当前 AppImage 修复分支承载待验证的版本标签；修复完成后应合并回 master。
+            if [[ "$branch" =~ origin/(master|v[0-9]+\.[0-9]+\.[0-9]+|fix/appimage-runtime-dependencies)$ ]]; then
               release_branch_found=true
               break
             fi

--- a/tools/linux/ci-package.sh
+++ b/tools/linux/ci-package.sh
@@ -63,6 +63,45 @@ fix_permissions() {
     chmod 755 "$appdir/AppRun.wrapped" 2>/dev/null || true
 }
 
+ensure_qt_quick_controls_library() {
+    local appdir="$1"
+    local required_library="$appdir/usr/lib/libQt6QuickControls2.so.6"
+
+    if [ -f "$required_library" ] && [ ! -L "$required_library" ]; then
+        return
+    fi
+
+    local qt_libs="${QT_LIBS:-}"
+    if [ -z "$qt_libs" ] && command -v qmake >/dev/null 2>&1; then
+        qt_libs="$(qmake -query QT_INSTALL_LIBS 2>/dev/null || true)"
+    fi
+
+    local source_library=""
+    if [ -d "$qt_libs" ]; then
+        source_library="$(find "$qt_libs" -maxdepth 1 -type f \
+            \( -name "libQt6QuickControls2.so.6" -o -name "libQt6QuickControls2.so.6.*" \) \
+            -print -quit)"
+    fi
+    if [ -z "$source_library" ] && [ -d /opt/qt ]; then
+        source_library="$(find /opt/qt -type f \
+            \( -name "libQt6QuickControls2.so.6" -o -name "libQt6QuickControls2.so.6.*" \) \
+            -print -quit 2>/dev/null)"
+    fi
+    if [ -z "$source_library" ]; then
+        echo "ERROR: Qt Quick Controls 2 library is missing from AppDir and Qt installation" >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$required_library")"
+    rm -f "$required_library"
+    cp -L "$source_library" "$required_library"
+    if [ ! -f "$required_library" ] || [ -L "$required_library" ]; then
+        echo "ERROR: Qt Quick Controls 2 library was not restored as a regular file" >&2
+        exit 1
+    fi
+    echo "✓ Restored libQt6QuickControls2.so.6 from $source_library"
+}
+
 render_nfpm_config() {
     local appdir="$1"
     local version="$2"
@@ -102,6 +141,10 @@ package_appimage() {
 
     sed -i "s|^Exec=.*easykiconverter|Exec=AppRun|" "$appdir/io.github.tangsangsimida.easykiconverter.desktop"
     sed -i "s|^Exec=.*easykiconverter|Exec=AppRun|" "$appdir/usr/share/applications/io.github.tangsangsimida.easykiconverter.desktop"
+
+    # artifact 传输或 linuxdeploy 处理可能丢失 Qt 主库的符号链接目标。
+    # 在 appimagetool 读取 AppDir 前强制恢复为真实文件，避免运行时退出 127。
+    ensure_qt_quick_controls_library "$appdir"
 
     # linuxdeploy 可能在准备阶段新建或覆盖包装启动脚本，必须在 appimagetool
     # 读取 AppDir 前再次修复两个启动文件的执行权限。

--- a/tools/linux/ci-package.sh
+++ b/tools/linux/ci-package.sh
@@ -134,20 +134,17 @@ package_appimage() {
 
     fix_permissions "$appdir"
 
-    # 先只准备 AppDir，避免 linuxdeploy 内置 output 插件在权限修复前生成 AppImage。
-    /opt/linuxdeploy/AppRun --appdir "$appdir" \
-        --executable "$appdir/usr/bin/easykiconverter" \
-        --desktop-file "$appdir/io.github.tangsangsimida.easykiconverter.desktop"
-
+    # build-core 阶段已经完成依赖部署。这里不能再次运行 linuxdeploy，
+    # 否则它会重写自定义 AppRun 并生成 AppRun.wrapped，导致 AppImage
+    # 启动时绕过 AppRun 中的 LD_LIBRARY_PATH 配置。
     sed -i "s|^Exec=.*easykiconverter|Exec=AppRun|" "$appdir/io.github.tangsangsimida.easykiconverter.desktop"
     sed -i "s|^Exec=.*easykiconverter|Exec=AppRun|" "$appdir/usr/share/applications/io.github.tangsangsimida.easykiconverter.desktop"
 
-    # artifact 传输或 linuxdeploy 处理可能丢失 Qt 主库的符号链接目标。
+    # artifact 传输可能丢失 Qt 主库的符号链接目标。
     # 在 appimagetool 读取 AppDir 前强制恢复为真实文件，避免运行时退出 127。
     ensure_qt_quick_controls_library "$appdir"
 
-    # linuxdeploy 可能在准备阶段新建或覆盖包装启动脚本，必须在 appimagetool
-    # 读取 AppDir 前再次修复两个启动文件的执行权限。
+    # appimagetool 读取 AppDir 前再次修复启动文件的执行权限。
     fix_permissions "$appdir"
 
     local appimagetool="/opt/linuxdeploy/plugins/linuxdeploy-plugin-appimage/usr/bin/appimagetool"


### PR DESCRIPTION
## 描述

- 修复 AppImage 打包阶段重复重写启动脚本，避免运行时丢失 Qt Quick Controls 2 动态库。
- 确保 AppImage 中的 Qt 主库以真实文件形式打包，避免符号链接导致运行环境找不到库文件。
- 修复发布资产提交哈希命名校验对架构分隔符的兼容性。
- 修复 Windows 校验和文件 CRLF 换行导致的资产匹配失败。
- 临时允许当前修复分支执行发布验证，便于在 `master` 回退期间完成验证。

## 相关 Issue

- 无。

## 更改类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化
- [x] 测试相关
- [ ] 其他

## 测试

- [x] 单元测试通过
- [x] 手动测试
- [ ] 添加了新的测试用例
- 本地构建和测试通过：`python3 tools/python/build_project.py --test`。
- GitHub Actions 已验证 Linux amd64/arm64 AppImage 生成、启动冒烟测试以及各平台打包流程。
- 最近一次工作流用于验证 Windows 校验和文件的 CRLF 兼容性。

## 检查清单

- [x] 代码遵循项目的编码规范
- [ ] 添加了必要的文档
- [x] 添加了必要的测试
- [x] 所有测试通过
- [ ] 更新了相关文档
- [x] 提交信息符合规范

## 截图（如果适用）

- 不适用。

## 附加信息

- `master` 已回退到问题修复前的提交，本分支集中包含 AppImage 发布流程及资产校验修复，评审通过后合并回 `master`。
- 当前分支包含 5 个提交，目标分支为 `master`。